### PR TITLE
Fix typo in python/README.md

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -11,7 +11,7 @@ Usage
 Install `opening-hours-py` from PyPI, for example using pip:
 
 ```bash
-pip install --user opening-hours-rs
+pip install --user opening-hours-py
 ```
 
 Then, the main object that you will interact with will be `OpeningHours`:


### PR DESCRIPTION
Thanks for the nice library! 
I found a typo in python/README.md, PTAL!