### PR TITLE
More robust week selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1
+
+### Rust
+
+- More robust week selector
+
 ## 0.11.0
 
 ### General

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "compact-calendar"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
 ]
@@ -642,7 +642,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opening-hours"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-py"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-syntax"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -34,9 +34,9 @@ log = ["opening-hours-syntax/log", "dep:log"]
 
 [dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "0.11.0" }
+compact-calendar = { path = "compact-calendar", version = "0.11.1" }
 flate2 = "1.0"
-opening-hours-syntax = { path = "opening-hours-syntax", version = "0.11.0" }
+opening-hours-syntax = { path = "opening-hours-syntax", version = "0.11.1" }
 sunrise-next = "1.2"
 
 # Feature: log (default)
@@ -51,7 +51,7 @@ tzf-rs = { version = "0.4", default-features = false, optional = true }
 
 [build-dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "0.11.0" }
+compact-calendar = { path = "compact-calendar", version = "0.11.1" }
 country-boundaries = { version = "1.2", optional = true }
 flate2 = "1.0"
 rustc_version = "0.4.0"

--- a/compact-calendar/Cargo.toml
+++ b/compact-calendar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-calendar"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-py/Cargo.toml
+++ b/opening-hours-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-py"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -21,12 +21,12 @@ pyo3-log = "0.12"
 
 [dependencies.opening-hours]
 path = ".."
-version = "0.11.0"
+version = "0.11.1"
 features = ["log", "auto-country", "auto-timezone"]
 
 [dependencies.opening-hours-syntax]
 path = "../opening-hours-syntax"
-version = "0.11.0"
+version = "0.11.1"
 features = ["log"]
 
 [dependencies.pyo3]

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-syntax"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-syntax/src/grammar.pest
+++ b/opening-hours-syntax/src/grammar.pest
@@ -154,7 +154,7 @@ day_offset = { space ~ plus_or_minus ~ positive_number ~ space ~ "day" ~ "s"? }
 
 // Week selector
 
-week_selector = { "week" ~ week ~ ( "," ~ week )* }
+week_selector = { "week" ~ space? ~ week ~ ( "," ~ week )* }
 
 week = { weeknum ~ ( "-" ~ weeknum ~  ( "/" ~ positive_number )? )? }
 
@@ -252,9 +252,9 @@ daynum_digits = {
 }
 
 weeknum = @{
-           "0" ~ '1'..'9'  // 01 -> 09
-    | '1'..'4' ~ '0'..'9'  // 10 -> 49
+      '1'..'4' ~ '0'..'9'  // 10 -> 49
     |      "5" ~ '0'..'3'  // 50 -> 53
+    |     "0"? ~ '1'..'9'  // 01 -> 09
 }
 
 month = {

--- a/opening-hours-syntax/src/rules/day.rs
+++ b/opening-hours-syntax/src/rules/day.rs
@@ -344,7 +344,7 @@ pub struct WeekRange {
 
 impl Display for WeekRange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.range.start())?;
+        write!(f, "week {}", self.range.start())?;
 
         if self.range.start() != self.range.end() {
             write!(f, "-{}", self.range.end())?;

--- a/opening-hours/src/tests/data/sample.txt
+++ b/opening-hours/src/tests/data/sample.txt
@@ -154,6 +154,51 @@ We-Fr 12:00-24:00 ; Sa 11:00-24:00 ; Su 11:00-22:30 ; PH off ; 2021 Mar 26-Apr 1
 We-Sa 10:00-23:00 ; Su 10:00-21:00 ; PH off
 We-Su 11:00-23:55 ; PH off
 Mo-Sa 07:00-19:00; PH Su off
+# Examples from https://openingh.ypid.de/evaluation_tool/
+Mo-Fr 10:00-20:00; PH off
+Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3],Th[-1] off
+00:00-24:00; Tu-Su,PH 08:30-09:00 off; Tu-Su 14:00-14:30 off; Mo 08:00-13:00 off
+Fr-Sa 18:00-06:00; PH off
+Mo 10:00-12:00,12:30-15:00
+Mo 10:00-12:00,12:30-15:00; Tu-Fr 08:00-12:00,12:30-15:00; Sa 08:00-12:00
+24/7
+"only after registration"; PH off
+22:00-23:00; PH off
+08:00-11:00; PH off
+open; Mo 15:00-16:00 off; PH off
+Mo-Su 22:00-23:00; We,PH off
+We-Fr 10:00-24:00 open "it is open" || "please call"; PH off
+Mo-Fr 08:00-11:00 || Tu-Th,PH open "Emergency only"
+Tu-Th,We 22:00-23:00 open "Hot meals"; PH off
+Mo 12:00-14:00 open "female only", Mo 14:00-16:00 open "male only"; PH off
+Apr: 22:00-23:00; PH off
+Jul-Jan: 22:00-23:00; PH off
+Jan-Jul: 22:00-23:00; PH off
+Jul 23-Jan 3: "needs reservation by phone"; PH off
+Jul 23-Jan 3: 22:00-23:00 "Please make a reservation by phone."; PH off
+Jul 23-Jan 3: 08:00-11:00 "Please make a reservation by phone."; PH off
+Jan 23-Jul 3: 22:00-23:00 "Please make a reservation by phone."; PH off
+# Mar Su[-1]-Dec Su[1] -2 days: 22:00-23:00; PH off
+Sa[1],Sa[1] +1 day 10:00-12:00 open "first weekend in the month"; PH off
+# Sa[-1],Sa[-1] +1 day 10:00-12:00 open "last weekend in the month"; PH off
+Sa-Su 00:00-24:00; PH off
+Mo-Fr 00:00-24:00; PH off
+sunrise-sunset open "Beware of sunburn!"; PH off
+sunset-sunrise open "Beware of vampires!"; PH off
+# (sunset+01:00)-24:00 || closed "No drink before sunset!"; PH off
+22:00+; PH off
+Tu,PH 23:59-22:59
+We-Mo,PH 23:59-22:59
+week 2-52/2 We 00:00-24:00; week 1-53/2 Sa 00:00-24:00; PH off
+week 4-16 We 00:00-24:00; week 38-42 Sa 00:00-24:00; PH off
+2012 easter -2 days-2012 easter +2 days: open "Around easter"; PH off
+24/7 closed "always closed"
+# 2013,2015,2050-2053,2055/2,2020-2029/3,2060+ Jan 1, documentation
+Jan 23-Feb 11,Feb 12 00:00-24:00; PH off
+Apr-Oct Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00; Aug Su[-1] 10:00-18:00; PH off
+Mo-Fr 08:00-12:00, We 14:00-18:00; Su,PH off
+# 00:00-24:00 week 6 Mo-Su Feb; PH off, (check out the error correction and the prettify function for the opening_hours value)
+# monday, Tu, wE, TH 12:00 - 20:00 ; 14:00-16:00 Off ; closed public Holiday, (check out the error correction and the prettify function for the opening_hours value)
 
 # This is a tough one, according to the grammar weekday should not be part of an interval.
 # "check website http://www.senat.fr/visite/jardin/horaires.html"; Mar Su[-1]-Sep 30 07:30-19:15+ open "check closing time on website http://www.senat.fr/visite/jardin/horaires.html"; (sunset-00:10)-(sunrise-00:50) closed; 21:30-07:30 closed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "opening-hours-py"
 version = "0.11.1"
 description = "A parser for the opening_hours fields from OpenStreetMap."
 authors = ["Rémi Dupré <remi@dupre.io>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opening-hours-py"
-version = "0.11.0"
+version = "0.11.1"
 description = "A parser for the opening_hours fields from OpenStreetMap."
 authors = ["Rémi Dupré <remi@dupre.io>"]
 


### PR DESCRIPTION

## 📋 Before Merge Checklist

1. [x] I have chosen a new version number with respect to [semver](https://semver.org/)
2. [x] I have updated the version in these files consistently: *Cargo.toml*, *compact-calendar/Cargo.toml*, *opening-hours-syntax/Cargo.toml*, *python/Cargo.toml* and *pyproject.toml*
3. [x] I have updated *CHANGELOG.md*


This tolerates a space between `week` keyword and the week selector. It also tolerates week number to not be prefixed by 0 for the first 10 weeks (aka 1 == 01,...)
It fixes the display of week selector by adding the week keyword.

I added a list of examples from https://openingh.ypid.de/evaluation_tool in `\opening-hours\src\tests\data\sample.txt` to test this. Some examples have been commented as they are not parsable by this library.

Fixes #63 