### PR TITLE
Switch to sunrise from sunrise-next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.2
+
+### Rust
+
+- Switch from `sunrise-next` dependency back to `sunrise` as all changes
+  have been upstreamed.
+
 ## 1.1.1
 
 ### Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "compact-calendar"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
 ]
@@ -718,7 +718,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opening-hours"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-py"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-syntax"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
  "log",
  "opening-hours-syntax",
  "rustc_version",
- "sunrise-next",
+ "sunrise",
  "tzf-rs",
 ]
 
@@ -1288,10 +1288,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
-name = "sunrise-next"
-version = "1.2.4"
+name = "sunrise"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8452cee9bbdb70d30684c5cf06082a5a09f477a8f3ab91a2e79c4cedcf9b2d3"
+checksum = "ae9103c11df35c145a7faa215c7af11343b6b4f26374b89b288ad9da0ea9042d"
 dependencies = [
  "chrono",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,9 +1289,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sunrise"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9103c11df35c145a7faa215c7af11343b6b4f26374b89b288ad9da0ea9042d"
+checksum = "08871f1db1390f915b7bb2ab2f1ac7370e8c78667857a15ae5cfea25da3262f2"
 dependencies = [
  "chrono",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -29,9 +29,9 @@ log = ["opening-hours-syntax/log", "dep:log"]
 
 [dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "1.1.1" }
+compact-calendar = { path = "compact-calendar", version = "1.1.2" }
 flate2 = "1.0"
-opening-hours-syntax = { path = "opening-hours-syntax", version = "1.1.1" }
+opening-hours-syntax = { path = "opening-hours-syntax", version = "1.1.2" }
 sunrise = "1.2"
 
 # Feature: log (default)
@@ -46,7 +46,7 @@ tzf-rs = { version = "0.4", default-features = false, optional = true }
 
 [build-dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "1.1.1" }
+compact-calendar = { path = "compact-calendar", version = "1.1.2" }
 country-boundaries = { version = "1.2", optional = true }
 flate2 = "1.0"
 rustc_version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ chrono = "0.4"
 compact-calendar = { path = "compact-calendar", version = "1.1.2" }
 flate2 = "1.0"
 opening-hours-syntax = { path = "opening-hours-syntax", version = "1.1.2" }
-sunrise = "1.2"
+sunrise = "1.2.1"
 
 # Feature: log (default)
 log = { version = "0.4", features = [ "kv" ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ chrono = "0.4"
 compact-calendar = { path = "compact-calendar", version = "1.1.1" }
 flate2 = "1.0"
 opening-hours-syntax = { path = "opening-hours-syntax", version = "1.1.1" }
-sunrise-next = "1.2"
+sunrise = "1.2"
 
 # Feature: log (default)
 log = { version = "0.4", features = [ "kv" ], optional = true }

--- a/compact-calendar/Cargo.toml
+++ b/compact-calendar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-calendar"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-py/Cargo.toml
+++ b/opening-hours-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-py"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -23,12 +23,12 @@ pyo3-stub-gen = "0.7"
 [dependencies.opening-hours-rs]
 package = "opening-hours"
 path = ".."
-version = "1.1.1"
+version = "1.1.2"
 features = ["log", "auto-country", "auto-timezone"]
 
 [dependencies.opening-hours-syntax]
 path = "../opening-hours-syntax"
-version = "1.1.1"
+version = "1.1.2"
 features = ["log"]
 
 [dependencies.pyo3]

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-syntax"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours/src/localization/coordinates.rs
+++ b/opening-hours/src/localization/coordinates.rs
@@ -1,15 +1,12 @@
-use chrono::{Datelike, NaiveDate};
+use chrono::NaiveDate;
 use opening_hours_syntax::rules::time::TimeEvent;
-use sunrise_next::{DawnType, SolarDay, SolarEvent};
+use sunrise::{DawnType, SolarDay, SolarEvent};
 
 /// A valid pair of geographic coordinates.
 ///
 /// See https://en.wikipedia.org/wiki/Geographic_coordinate_system
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub struct Coordinates {
-    lat: f64,
-    lon: f64,
-}
+pub struct Coordinates(sunrise::Coordinates);
 
 impl Coordinates {
     /// Validate a pair of latitude / longitude.
@@ -17,12 +14,10 @@ impl Coordinates {
     /// Return `None` if values are out of range (`abs(lat) > 90` or
     /// `abs(lon) > 180`).
     pub const fn new(lat: f64, lon: f64) -> Option<Self> {
-        if lat.is_nan() || lon.is_nan() || lat < -90.0 || lat > 90.0 || lon < -180.0 || lon > 180.0
-        {
-            return None;
+        match sunrise::Coordinates::new(lat, lon) {
+            Some(c) => Some(Self(c)),
+            None => None,
         }
-
-        Some(Self { lat, lon })
     }
 
     /// Get the time for a sun event at a given date.
@@ -34,24 +29,23 @@ impl Coordinates {
             TimeEvent::Dusk => SolarEvent::Dusk(DawnType::Civil),
         };
 
-        let solar_day = SolarDay::new(self.lat, self.lon, date.year(), date.month(), date.day());
-        let timestamp = solar_day.event_time(solar_event);
-        chrono::DateTime::from_timestamp(timestamp, 0).expect("invalid timestamp")
+        let solar_day = SolarDay::new(self.0, date);
+        solar_day.event_time(solar_event)
     }
 
     /// Get latitude component.
     pub fn lat(&self) -> f64 {
-        self.lat
+        self.0.lat()
     }
 
     /// Get longitude component.
     pub fn lon(&self) -> f64 {
-        self.lon
+        self.0.lon()
     }
 }
 
 impl std::fmt::Display for Coordinates {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}, {})", self.lat, self.lon)
+        write!(f, "({}, {})", self.lat(), self.lon())
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 
 [tool.poetry]
 name = "opening_hours_py"
-version = "1.1.1"
+version = "1.1.2"
 description = "A parser for the opening_hours fields from OpenStreetMap."
 authors = ["Rémi Dupré <remi@dupre.io>"]
 package-mode = false


### PR DESCRIPTION
This switches from `sunrise` to `sunrise-next` as `sunrise-next` has been yanked, as you upstreamed all the changes as far as I understood.

Maybe the 2.0 release has a different approach to this, but the way this change works should be completly backwards compatible, while allowing `cargo add opening-hours` to work again.

## 📋 Before Merge Checklist

1. [x] I have chosen a new version number with respect to [semver](https://semver.org/)
2. [x] I have updated the version in these files consistently: *Cargo.toml*, *compact-calendar/Cargo.toml*, *opening-hours-syntax/Cargo.toml*, *python/Cargo.toml* and *pyproject.toml*
3. [x] I have updated *CHANGELOG.md*
