### PR TITLE
No std syntax

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,7 @@ jobs:
           - { crate: ".", features: "log,auto-country,auto-timezone" }
           - { crate: ".", features: "log,auto-timezone" }
           - { crate: "opening-hours-syntax", features: "log" }
+          - { crate: "opening-hours-syntax", features: "std" }
     defaults:
       run:
         working-directory: ${{ matrix.crate }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "fuzz/corpus"]
 	path = fuzz/corpus
-	url = git@github.com:remi-dupre/opening-hours-rs-fuzz-corpus.git
+	url = https://github.com/remi-dupre/opening-hours-rs-fuzz-corpus.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 1.2.2
+## 1.3.0
 
 ### General
 
 - Fix: expression stringification was not idempotent in some cases
+
+### Rust
+
+- opening-hours-syntax: support for no-std environment (ft. @hosseinpro)
 
 ## 1.2.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "compact-calendar"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "chrono",
 ]
@@ -801,7 +801,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opening-hours"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-py"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-syntax"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -29,9 +29,9 @@ log = ["opening-hours-syntax/log", "dep:log"]
 
 [dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "1.2.2" }
+compact-calendar = { path = "compact-calendar", version = "1.3.0" }
 flate2 = "1.0"
-opening-hours-syntax = { path = "opening-hours-syntax", version = "1.2.2" }
+opening-hours-syntax = { path = "opening-hours-syntax", version = "1.3.0" }
 sunrise = "3.0"
 
 # Feature: log (default)
@@ -46,7 +46,7 @@ tzf-rs = { version = "1.3", default-features = false, features = ["bundled"], op
 
 [build-dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "1.2.2" }
+compact-calendar = { path = "compact-calendar", version = "1.3.0" }
 country-boundaries = { version = "1.2", optional = true }
 flate2 = "1.0"
 

--- a/compact-calendar/Cargo.toml
+++ b/compact-calendar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-calendar"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-py/Cargo.toml
+++ b/opening-hours-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-py"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -23,12 +23,12 @@ pyo3-stub-gen = "0.17"
 [dependencies.opening-hours-rs]
 package = "opening-hours"
 path = ".."
-version = "1.2.2"
+version = "1.3.0"
 features = ["log", "auto-country", "auto-timezone"]
 
 [dependencies.opening-hours-syntax]
 path = "../opening-hours-syntax"
-version = "1.2.2"
+version = "1.3.0"
 features = ["log"]
 
 [dependencies.pyo3]

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -13,9 +13,10 @@ edition = "2021"
 [dependencies]
 chrono = { version = "0.4", default-features = false }
 log = { version = "0.4", features = [ "kv" ], optional = true }
-pest = "2.0"
-pest_derive = "2.0"
+pest = { version = "2.0", default-features = false }
+pest_derive = { version = "2.0", default-features = false }
 
 [features]
-default = ["log"]
+default = ["std", "log"]
+std = ["chrono/std", "pest/std", "pest_derive/std"]
 log = ["dep:log"]

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-syntax"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-syntax/src/display.rs
+++ b/opening-hours-syntax/src/display.rs
@@ -1,6 +1,9 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
-pub(crate) fn write_days_offset(f: &mut std::fmt::Formatter<'_>, offset: i64) -> std::fmt::Result {
+pub(crate) fn write_days_offset(
+    f: &mut core::fmt::Formatter<'_>,
+    offset: i64,
+) -> core::fmt::Result {
     if offset == 0 {
         return Ok(());
     }
@@ -21,9 +24,9 @@ pub(crate) fn write_days_offset(f: &mut std::fmt::Formatter<'_>, offset: i64) ->
 }
 
 pub(crate) fn write_selector(
-    f: &mut std::fmt::Formatter<'_>,
+    f: &mut core::fmt::Formatter<'_>,
     seq: &[impl Display],
-) -> std::fmt::Result {
+) -> core::fmt::Result {
     let Some(first) = seq.first() else {
         return Ok(());
     };

--- a/opening-hours-syntax/src/error.rs
+++ b/opening-hours-syntax/src/error.rs
@@ -1,8 +1,10 @@
-use std::fmt;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
 
 use crate::parser::Rule;
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Clone, Debug)]
 pub enum Error {
@@ -34,6 +36,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/opening-hours-syntax/src/extended_time.rs
+++ b/opening-hours-syntax/src/extended_time.rs
@@ -1,5 +1,5 @@
-use std::convert::TryInto;
-use std::fmt::{Debug, Display};
+use core::convert::TryInto;
+use core::fmt::{Debug, Display};
 
 use chrono::{NaiveTime, Timelike};
 
@@ -136,13 +136,13 @@ impl ExtendedTime {
 }
 
 impl Display for ExtendedTime {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:02}:{:02}", self.hour, self.minute)
     }
 }
 
 impl Debug for ExtendedTime {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::result::Result<(), core::fmt::Error> {
         write!(f, "{self}")
     }
 }

--- a/opening-hours-syntax/src/lib.rs
+++ b/opening-hours-syntax/src/lib.rs
@@ -1,4 +1,8 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
 
 #[macro_use]
 extern crate pest_derive;

--- a/opening-hours-syntax/src/normalize/canonical.rs
+++ b/opening-hours-syntax/src/normalize/canonical.rs
@@ -1,6 +1,7 @@
-use std::cmp::Ordering;
-use std::ops::Range;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::ops::Range;
 
 use chrono::Weekday;
 

--- a/opening-hours-syntax/src/normalize/frame.rs
+++ b/opening-hours-syntax/src/normalize/frame.rs
@@ -4,8 +4,8 @@
 // -- Framable
 // --
 
-use std::cmp::Ordering;
-use std::ops::{Range, RangeInclusive};
+use core::cmp::Ordering;
+use core::ops::{Range, RangeInclusive};
 
 use chrono::Weekday;
 
@@ -146,9 +146,9 @@ pub(crate) trait Bounded: Ord + Sized {
     fn split_inverted_range(range: Range<Self>) -> impl Iterator<Item = Range<Self>> {
         if range.start >= range.end {
             // start == end when a wrapping range gets expanded from exclusive to inclusive range
-            std::iter::once(Self::BOUND_START..range.end).chain(Some(range.start..Self::BOUND_END))
+            core::iter::once(Self::BOUND_START..range.end).chain(Some(range.start..Self::BOUND_END))
         } else {
-            std::iter::once(range).chain(None)
+            core::iter::once(range).chain(None)
         }
     }
 }

--- a/opening-hours-syntax/src/normalize/mod.rs
+++ b/opening-hours-syntax/src/normalize/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn canonical_to_seq(canonical: Canonical) -> impl Iterator<Item = Rul
     // Parts of this paving will be removed until it is empty
     let mut canonical_remaining = canonical.clone();
 
-    std::iter::from_fn(move || {
+    core::iter::from_fn(move || {
         // Extract open periods first, then unknowns
         let ((kind, comments), mut selector) =
             [RuleKind::Open, RuleKind::Unknown, RuleKind::Closed]

--- a/opening-hours-syntax/src/normalize/paving.rs
+++ b/opening-hours-syntax/src/normalize/paving.rs
@@ -7,8 +7,9 @@
 //! for this problem in two dimensions and for boolean values :
 //! https://dl.acm.org/doi/10.1145/73833.73871
 
-use std::fmt::Debug;
-use std::ops::Range;
+use alloc::vec::Vec;
+use core::fmt::Debug;
+use core::ops::Range;
 
 pub(crate) type Paving1D<T, Val> = Dim<T, Cell<Val>>;
 pub(crate) type Paving2D<T, U, Val> = Dim<T, Paving1D<U, Val>>;
@@ -209,7 +210,7 @@ impl<Val: Clone + Default + Eq + Ord> Paving for Cell<Val> {
         filter: impl Fn(&Self::Value) -> bool,
     ) -> Option<(Self::Value, Self::Selector)> {
         if filter(&self.inner) {
-            Some((std::mem::take(&mut self.inner), EmptyPavingSelector))
+            Some((core::mem::take(&mut self.inner), EmptyPavingSelector))
         } else {
             None
         }
@@ -238,7 +239,7 @@ impl<T: Clone + Ord, U: Paving> Default for Dim<T, U> {
 }
 
 impl<T: Clone + Ord + Debug, U: Paving + Debug> Debug for Dim<T, U> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if self.cols.is_empty() {
             f.debug_tuple("Dim::Empty").field(&self.cols).finish()?;
         }

--- a/opening-hours-syntax/src/parser.rs
+++ b/opening-hours-syntax/src/parser.rs
@@ -21,8 +21,10 @@ use crate::rules::time as ts;
 #[cfg(feature = "log")]
 use core::sync::atomic::{AtomicBool, Ordering};
 
+/// Keep track of whether a feature warning was emitted for easter support. This ensures that a
+/// warning is not spammed for a single process session.
 #[cfg(feature = "log")]
-static WARN_EASTER: AtomicBool = AtomicBool::new(false);
+static WARNING_EASTER_EMITTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
@@ -598,9 +600,10 @@ fn build_date_from(pair: Pair<Rule>) -> ds::Date {
     match pairs.peek().expect("empty date (from)").as_rule() {
         Rule::variable_date => {
             #[cfg(feature = "log")]
-            if !WARN_EASTER.swap(true, Ordering::Relaxed) {
+            if !WARNING_EASTER_EMITTED.swap(true, Ordering::Relaxed) {
                 log::warn!("Easter is not supported yet");
             }
+
             ds::Date::Easter { year }
         }
         Rule::month => ds::Date::Fixed {

--- a/opening-hours-syntax/src/parser.rs
+++ b/opening-hours-syntax/src/parser.rs
@@ -1,9 +1,11 @@
-use std::cmp::Ord;
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::ops::RangeInclusive;
-use std::sync::Arc;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp::Ord;
+use core::convert::TryInto;
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::ops::RangeInclusive;
 
 use chrono::Duration;
 
@@ -17,7 +19,10 @@ use crate::rules::day::{self as ds, WeekNum, Year};
 use crate::rules::time as ts;
 
 #[cfg(feature = "log")]
-static WARN_EASTER: std::sync::Once = std::sync::Once::new();
+use core::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(feature = "log")]
+static WARN_EASTER: AtomicBool = AtomicBool::new(false);
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
@@ -593,7 +598,9 @@ fn build_date_from(pair: Pair<Rule>) -> ds::Date {
     match pairs.peek().expect("empty date (from)").as_rule() {
         Rule::variable_date => {
             #[cfg(feature = "log")]
-            WARN_EASTER.call_once(|| log::warn!("Easter is not supported yet"));
+            if !WARN_EASTER.swap(true, Ordering::Relaxed) {
+                log::warn!("Easter is not supported yet");
+            }
             ds::Date::Easter { year }
         }
         Rule::month => ds::Date::Fixed {

--- a/opening-hours-syntax/src/rules/day.rs
+++ b/opening-hours-syntax/src/rules/day.rs
@@ -1,6 +1,7 @@
-use std::convert::{TryFrom, TryInto};
-use std::fmt::Display;
-use std::ops::{Deref, DerefMut, RangeInclusive};
+use alloc::vec::Vec;
+use core::convert::{TryFrom, TryInto};
+use core::fmt::Display;
+use core::ops::{Deref, DerefMut, RangeInclusive};
 
 use chrono::prelude::Datelike;
 use chrono::{Duration, NaiveDate};
@@ -52,7 +53,11 @@ impl DaySelector {
     ///
     /// If `force` is set to true, this is guaranteed to yield a non-empty string by adding "Mo-Su"
     /// as fallback.
-    pub(crate) fn display(&self, f: &mut std::fmt::Formatter<'_>, force: bool) -> std::fmt::Result {
+    pub(crate) fn display(
+        &self,
+        f: &mut core::fmt::Formatter<'_>,
+        force: bool,
+    ) -> core::fmt::Result {
         if force && self.is_empty() {
             return write!(f, "Mo-Su");
         }
@@ -80,7 +85,7 @@ impl DaySelector {
 }
 
 impl Display for DaySelector {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.display(f, false)
     }
 }
@@ -112,7 +117,7 @@ pub struct YearRange {
 }
 
 impl Display for YearRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.range.start().deref())?;
 
         if self.range.start() != self.range.end() {
@@ -142,7 +147,7 @@ pub enum MonthdayRange {
 }
 
 impl Display for MonthdayRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Month { range, year } => {
                 if let Some(year) = year {
@@ -203,7 +208,7 @@ impl Date {
 }
 
 impl Display for Date {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Date::Fixed { year, month, day } => {
                 if let Some(year) = year {
@@ -263,7 +268,7 @@ impl DateOffset {
 }
 
 impl Display for DateOffset {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.wday_offset)?;
         write_days_offset(f, self.day_offset)?;
         Ok(())
@@ -287,7 +292,7 @@ impl Default for WeekDayOffset {
 }
 
 impl Display for WeekDayOffset {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::None => {}
             Self::Next(wday) => write!(f, "+{}", wday_str(*wday))?,
@@ -315,7 +320,7 @@ pub enum WeekDayRange {
 }
 
 impl Display for WeekDayRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Fixed { range, offset, nth_from_start, nth_from_end } => {
                 write!(f, "{}", wday_str(*range.start()))?;
@@ -371,7 +376,7 @@ pub enum HolidayKind {
 }
 
 impl Display for HolidayKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Public => write!(f, "PH"),
             Self::School => write!(f, "SH"),
@@ -407,7 +412,7 @@ pub struct WeekRange {
 }
 
 impl Display for WeekRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if self.range.start() == self.range.end() && self.step == 1 {
             return write!(f, "{:02}", **self.range.start());
         }
@@ -494,7 +499,7 @@ impl Month {
 }
 
 impl Display for Month {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", &self.as_str()[..3])
     }
 }

--- a/opening-hours-syntax/src/rules/mod.rs
+++ b/opening-hours-syntax/src/rules/mod.rs
@@ -1,8 +1,9 @@
 pub mod day;
 pub mod time;
 
-use std::fmt::Display;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt::Display;
 
 use crate::normalize::frame::Bounded;
 use crate::normalize::paving::{Paving, Paving5D, UnpackFromBack};
@@ -87,7 +88,7 @@ impl OpeningHoursExpression {
 }
 
 impl Display for OpeningHoursExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let Some(first) = self.rules.first() else {
             return write!(f, "closed");
         };
@@ -138,9 +139,9 @@ impl RuleSequence {
     /// non-empty string by adding "Mo-Su" as fallback.
     pub(crate) fn display(
         &self,
-        f: &mut std::fmt::Formatter<'_>,
+        f: &mut core::fmt::Formatter<'_>,
         force_day_selector: bool,
-    ) -> std::fmt::Result {
+    ) -> core::fmt::Result {
         let mut is_empty;
 
         if self.is_constant() {
@@ -182,7 +183,7 @@ impl RuleSequence {
 }
 
 impl Display for RuleSequence {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.display(f, false)
     }
 }
@@ -208,7 +209,7 @@ impl RuleKind {
 }
 
 impl Display for RuleKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }

--- a/opening-hours-syntax/src/rules/time.rs
+++ b/opening-hours-syntax/src/rules/time.rs
@@ -1,6 +1,7 @@
-use std::cmp::Ordering;
-use std::fmt::Display;
-use std::ops::Range;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt::Display;
+use core::ops::Range;
 
 use chrono::Duration;
 
@@ -50,7 +51,7 @@ impl Default for TimeSelector {
 }
 
 impl Display for TimeSelector {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write_selector(f, &self.time)
     }
 }
@@ -76,7 +77,7 @@ impl TimeSpan {
 }
 
 impl Display for TimeSpan {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.range.start)?;
 
         if !self.open_end || self.range.end != Time::Fixed(ExtendedTime::MIDNIGHT_24) {
@@ -108,7 +109,7 @@ pub enum Time {
 }
 
 impl Display for Time {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Fixed(time) => write!(f, "{time}"),
             Self::Variable(time) => write!(f, "{time}"),
@@ -125,7 +126,7 @@ pub struct VariableTime {
 }
 
 impl Display for VariableTime {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.event)?;
 
         match self.offset.cmp(&0) {
@@ -158,7 +159,7 @@ impl TimeEvent {
 }
 
 impl Display for TimeEvent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }

--- a/opening-hours-syntax/src/sorted_vec.rs
+++ b/opening-hours-syntax/src/sorted_vec.rs
@@ -1,7 +1,8 @@
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::convert::From;
-use std::ops::Deref;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::convert::From;
+use core::ops::Deref;
 
 /// A wrapper arround a [`Vec`] that is always sorted and with values repeating
 /// at most once.

--- a/opening-hours-syntax/src/tests/display.rs
+++ b/opening-hours-syntax/src/tests/display.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use crate::error::Result;
 use crate::parser::parse;
 use crate::tests::ex;

--- a/opening-hours-syntax/src/tests/normalize.rs
+++ b/opening-hours-syntax/src/tests/normalize.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use crate::error::Result;
 use crate::parser::parse;
 use crate::tests::ex;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ changelog = "https://github.com/remi-dupre/opening-hours-rs/blob/master/CHANGELO
 readme = "opening-hours-py/README.md"
 authors = [{name = "Rémi Dupré", email = "remi+openinghours@dupre.io"}]
 requires-python = "~=3.10"
-version = "1.2.2"
+version = "1.3.0"
 dynamic = ["license", "license-files"]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

  Make the `opening-hours-syntax` parser sub-crate compile under `#![no_std] + extern crate alloc` when its new default-enabled `std` feature is disabled. The top-level `opening-hours` crate and all existing users are unaffected —
  `std` remains on by default.

  ## Motivation

  The OSM `opening_hours` DSL is a natural fit for embedded contexts that can't pull `std`. The parser sub-crate is structurally close to `no_std` already — `chrono` is already `default-features = false` and `pest` 2.x has supported
  `no_std` for a while — but a small set of explicit `std::` paths blocks consumers from opting in.

  This PR is the minimum change to flip that gate, gated behind a new feature so nothing changes for current users.

  ## Changes

  **`opening-hours-syntax/Cargo.toml`**
  - Add `std` to default features.
  - New feature: `std = ["chrono/std", "pest/std", "pest_derive/std"]`.
  - Set `pest` and `pest_derive` to `default-features = false` so the `std` propagation is explicit.

  **`opening-hours-syntax/src/lib.rs`**
  - `#![cfg_attr(not(feature = "std"), no_std)]`
  - `#[macro_use] extern crate alloc;` (so `format!` / `vec!` work in the no_std build).

  **`opening-hours-syntax/src/*`** (mechanical)
  - Replace `use std::…` with `use core::…` / `use alloc::…` across the sub-crate (`fmt`, `cmp`, `convert`, `hash`, `ops`, `borrow`, `mem`, `iter`, `sync::Arc`).
  - Add explicit `use alloc::{boxed::Box, string::String, vec::Vec};` imports where the `std` prelude was previously implicit.

  **Two items that needed real attention, not pure relocation:**

  1. `impl std::error::Error for Error` in `src/error.rs` is now gated behind `#[cfg(feature = "std")]`. Not switching to `core::error::Error` to avoid bumping MSRV (would require ≥ 1.81). Happy to do that in a follow-up if you'd 
  prefer.
  2. `static WARN_EASTER: std::sync::Once` in `src/parser.rs` is replaced with `core::sync::atomic::AtomicBool` + `swap(true, Ordering::Relaxed)`. Same fire-once-ish semantics (under contention the warning could fire a small bounded 
  number of times, which seemed fine for a one-off log line), and crucially keeps the `log` feature working in `no_std` rather than gating it away.

  **`.gitmodules`**
  - Change `fuzz/corpus` submodule URL from `git@github.com:…` to `https://github.com/…` so cargo can fetch dependents in environments without SSH credentials (CI runners, build containers). Functionally equivalent — the contents are 
  identical and the SSH URL still works for write access.

  ## Verification

  | Config | Result |
  |---|---|
  | `cargo check -p opening-hours-syntax` (default features) | clean |
  | `cargo check -p opening-hours-syntax --no-default-features` | clean |
  | `cargo check -p opening-hours-syntax --no-default-features --target thumbv7em-none-eabihf` | clean (bare-metal ARM Cortex-M) |
  | `cargo test -p opening-hours-syntax` | 22/22 pass (7 unit + 15 doc) |

  Also exercised end-to-end inside a downstream `no_std` consumer (parser, AST, and `RuleSequence` iteration).

  ## Not in scope

  - The top-level `opening-hours` crate (depends on `flate2` + `sunrise` + `country-boundaries` for holiday/sun data — those need separate treatment and aren't needed for parser-only consumers).
  - `opening-hours-py` and `fuzz`.
  - Bumping MSRV. The `core::error::Error` switch would be a small follow-up if you decide that's acceptable.