### PR TITLE
fix: rust not deploying because of docs static path

### DIFF
--- a/.github/workflows/deploy-rust.yml
+++ b/.github/workflows/deploy-rust.yml
@@ -7,25 +7,19 @@ on:
 jobs:
   deploy-rust:
     runs-on: ubuntu-latest
-
-    strategy:
-      max-parallel: 1
-      matrix:
-        crate:
-          - compact-calendar
-          - opening-hours-syntax
-          - .
-
-    defaults:
-      run:
-        working-directory: ${{ matrix.crate }}
+    env:
+      PACKAGES: >-
+        -p compact-calendar
+        -p opening-hours
+        -p opening-hours-py
+        -p opening-hours-syntax
 
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Dry run
-        run: cargo publish --dry-run
+        run: cargo publish ${{ env.PACKAGES }} --dry-run
 
       - name: Login to crates.io
         run: cargo login $TOKEN
@@ -34,5 +28,5 @@ jobs:
           TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish ${{ env.PACKAGES }}
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/deploy-rust.yml
+++ b/.github/workflows/deploy-rust.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Dry run
+        run: cargo publish --dry-run
+
       - name: Login to crates.io
         run: cargo login $TOKEN
         if: github.ref == 'refs/heads/master'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+- Fix Rust crate not deploying because of docs static path.
+
 ## 2.1.0
 
 The normalization algorithm has been reworked:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "compact-calendar"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
 ]
@@ -810,7 +810,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opening-hours"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-py"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-syntax"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -29,9 +29,9 @@ log = ["dep:log"]
 
 [dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "2.1.0" }
+compact-calendar = { path = "compact-calendar", version = "2.1.1" }
 flate2 = "1.0"
-opening-hours-syntax = { path = "opening-hours-syntax", version = "2.1.0" }
+opening-hours-syntax = { path = "opening-hours-syntax", version = "2.1.1" }
 sunrise = "3.0"
 
 # Feature: log (default)
@@ -46,7 +46,7 @@ tzf-rs = { version = "1.3", default-features = false, features = ["bundled"], op
 
 [build-dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "2.1.0" }
+compact-calendar = { path = "compact-calendar", version = "2.1.1" }
 country-boundaries = { version = "1.2", optional = true }
 flate2 = "1.0"
 

--- a/compact-calendar/Cargo.toml
+++ b/compact-calendar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-calendar"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-py/Cargo.toml
+++ b/opening-hours-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-py"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -23,12 +23,12 @@ pyo3-stub-gen = "0.23"
 [dependencies.opening-hours-rs]
 package = "opening-hours"
 path = ".."
-version = "2.1.0"
+version = "2.1.1"
 features = ["log", "auto-country", "auto-timezone"]
 
 [dependencies.opening-hours-syntax]
 path = "../opening-hours-syntax"
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.pyo3]
 version = "0.29"

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-syntax"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours/doc/normalize.md
+++ b/opening-hours/doc/normalize.md
@@ -1,0 +1,1 @@
+../../opening-hours-syntax/doc/normalize.md

--- a/opening-hours/src/opening_hours.rs
+++ b/opening-hours/src/opening_hours.rs
@@ -111,7 +111,7 @@ impl<L: Localize> OpeningHours<L> {
     /// assert_eq!(oh.normalize().to_string(), "Mo-Sa");
     /// ```
     ///
-    #[doc = include_str!("../../opening-hours-syntax/doc/normalize.md")]
+    #[doc = include_str!("../doc/normalize.md")]
     pub fn normalize(&self) -> Self {
         Self {
             expr: Arc::new(self.expr.as_ref().clone().normalize()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ changelog = "https://github.com/remi-dupre/opening-hours-rs/blob/master/CHANGELO
 readme = "opening-hours-py/README.md"
 authors = [{name = "Rémi Dupré", email = "remi+openinghours@dupre.io"}]
 requires-python = "~=3.10"
-version = "2.1.0"
+version = "2.1.1"
 dynamic = ["license", "license-files"]
 
 [dependency-groups]


### PR DESCRIPTION
See https://users.rust-lang.org/t/include-str-does-not-work-when-releasing-because-of-changed-pathes/15551/19



## 📋 Before Merge Checklist

1. [ ] I have chosen a new version number with respect to [semver](https://semver.org/)
2. [ ] I have updated the version in these files consistently: *Cargo.toml*, *compact-calendar/Cargo.toml*, *opening-hours-syntax/Cargo.toml*, *python/Cargo.toml* and *pyproject.toml*
3. [ ] I have updated *CHANGELOG.md*
