### PR TITLE
fix: holiday offset display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.3
+
+- Fix: Display of opening hours that include a holiday offset like `PH -1 days 17:00-02:00`
+
 ## 2.1.2
 
 - Fix: variable time at the poles should behave correctly (for example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "compact-calendar"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "chrono",
 ]
@@ -810,7 +810,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opening-hours"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-py"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-syntax"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "chrono",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -29,9 +29,9 @@ log = ["dep:log"]
 
 [dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "2.1.2" }
+compact-calendar = { path = "compact-calendar", version = "2.1.3" }
 flate2 = "1.0"
-opening-hours-syntax = { path = "opening-hours-syntax", version = "2.1.2" }
+opening-hours-syntax = { path = "opening-hours-syntax", version = "2.1.3" }
 sunrise = "3.0"
 
 # Feature: log (default)
@@ -46,7 +46,7 @@ tzf-rs = { version = "1.3", default-features = false, features = ["bundled"], op
 
 [build-dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "2.1.2" }
+compact-calendar = { path = "compact-calendar", version = "2.1.3" }
 country-boundaries = { version = "1.2", optional = true }
 flate2 = "1.0"
 

--- a/compact-calendar/Cargo.toml
+++ b/compact-calendar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-calendar"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-py/Cargo.toml
+++ b/opening-hours-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-py"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -23,12 +23,12 @@ pyo3-stub-gen = "0.23"
 [dependencies.opening-hours-rs]
 package = "opening-hours"
 path = ".."
-version = "2.1.2"
+version = "2.1.3"
 features = ["log", "auto-country", "auto-timezone"]
 
 [dependencies.opening-hours-syntax]
 path = "../opening-hours-syntax"
-version = "2.1.2"
+version = "2.1.3"
 
 [dependencies.pyo3]
 version = "0.29"

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-syntax"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-syntax/src/rules/day.rs
+++ b/opening-hours-syntax/src/rules/day.rs
@@ -418,7 +418,7 @@ impl Display for WeekDayRange {
                 write!(f, "{kind}")?;
 
                 if *offset != 0 {
-                    write!(f, " {offset}")?;
+                    write!(f, " {offset} days")?;
                 }
             }
         }

--- a/opening-hours-syntax/src/tests/display.rs
+++ b/opening-hours-syntax/src/tests/display.rs
@@ -14,6 +14,7 @@ use crate::tests::parser_no_warn;
 #[case("(sunrise-00:10)-(sunset+01:15)")]
 #[case("(sunrise-00:10)-sunset")]
 #[case("sunrise-(sunset+01:15)")]
+#[case("PH -1 days 17:00-02:00")]
 fn display_stable(mut parser_no_warn: Parser, #[case] example: &str) {
     assert_eq!(
         parser_no_warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ changelog = "https://github.com/remi-dupre/opening-hours-rs/blob/master/CHANGELO
 readme = "opening-hours-py/README.md"
 authors = [{name = "Rémi Dupré", email = "remi+openinghours@dupre.io"}]
 requires-python = "~=3.10"
-version = "2.1.2"
+version = "2.1.3"
 dynamic = ["license", "license-files"]
 
 [dependency-groups]


### PR DESCRIPTION
When displaying opening hours with a holiday offset like `PH -1 days 17:00-02:00` the mandatory static string  "days" wasn't included.

## 📋 Before Merge Checklist

1. [x] I have chosen a new version number with respect to [semver](https://semver.org/)
2. [x] I have updated the version in these files consistently: *Cargo.toml*, *compact-calendar/Cargo.toml*, *opening-hours-syntax/Cargo.toml*, *python/Cargo.toml* and *pyproject.toml*
3. [x] I have updated *CHANGELOG.md*
