### PR TITLE
fix: time spans ending with sun events shouldn't be normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.4
+
+- Fix: time spans ending with a sun event shouldn't be normalized (there can be
+  a day overlap when working with extreme coordinates).
+
 ## 2.1.3
 
 - Fix: Display of opening hours that include a holiday offset like `PH -1 days 17:00-02:00`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "compact-calendar"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "chrono",
 ]
@@ -810,7 +810,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opening-hours"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-py"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "opening-hours-syntax"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "chrono",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -29,9 +29,9 @@ log = ["dep:log"]
 
 [dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "2.1.3" }
+compact-calendar = { path = "compact-calendar", version = "2.1.4" }
 flate2 = "1.0"
-opening-hours-syntax = { path = "opening-hours-syntax", version = "2.1.3" }
+opening-hours-syntax = { path = "opening-hours-syntax", version = "2.1.4" }
 sunrise = "3.0"
 
 # Feature: log (default)
@@ -46,7 +46,7 @@ tzf-rs = { version = "1.3", default-features = false, features = ["bundled"], op
 
 [build-dependencies]
 chrono = "0.4"
-compact-calendar = { path = "compact-calendar", version = "2.1.3" }
+compact-calendar = { path = "compact-calendar", version = "2.1.4" }
 country-boundaries = { version = "1.2", optional = true }
 flate2 = "1.0"
 

--- a/compact-calendar/Cargo.toml
+++ b/compact-calendar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compact-calendar"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -72,27 +72,34 @@ impl Debug for Data {
 /// Run a fuzzing test and return `true` if the example should be kept in
 /// corpus.
 pub fn run_fuzz_oh(data: Data) -> bool {
+    eprintln!("[dbg] Input: {data:#?}");
+
     if data.oh.len() > MAX_OH_LENGTH {
+        eprintln!("[dbg] Skipping because of input size");
         return false;
     }
 
     let Some(date) = DateTime::from_timestamp(data.date_secs, 0) else {
+        eprintln!("[dbg] Skipping because of invalid input date");
         return false;
     };
 
     let date = date.naive_utc();
 
     if date.year() < 1900 || date.year() > 9999 {
+        eprintln!("[dbg] Skipping because of invalid date range");
         return false;
     }
 
     let Ok(oh_1) = OpeningHours::from_str(&data.oh) else {
+        eprintln!("[dbg] Skipping because of invalid input");
         return false;
     };
 
     match &data.operation {
         Operation::DoubleNormalize => {
             let normalized = oh_1.normalize();
+            eprintln!("[dbg] Normalized: {normalized:?}");
             assert_eq!(normalized, normalized.clone().normalize());
         }
         Operation::Compare(compare_with) => {
@@ -116,21 +123,55 @@ pub fn run_fuzz_oh(data: Data) -> bool {
                 }
             };
 
+            eprintln!("[dbg] Compare with {oh_2}");
+
             if let Some([lat, lon]) = data.coords_float() {
                 let ctx = Context::from_coords(Coordinates::new(lat, lon).unwrap())
                     .approx_bound_interval_size(MAX_INTERVAL_RANGE);
 
                 let date = ctx.locale.datetime(date);
                 let oh_1 = oh_1.with_context(ctx.clone());
-                let oh_2 = oh_2.with_context(ctx.clone());
-                assert_eq!(oh_1.state(date), oh_2.state(date));
-                assert_eq!(oh_1.next_change(date), oh_2.next_change(date));
+                let oh_2 = oh_2.with_context(ctx);
+
+                // States should be equal
+                let state_1 = oh_1.state(date);
+                let state_2 = oh_2.state(date);
+
+                assert_eq!(
+                    state_1, state_2,
+                    "States differ at {date}: {state_1:?} != {state_2:?}"
+                );
+
+                // Next change should be equal
+                let next_change_1 = oh_1.next_change(date);
+                let next_change_2 = oh_2.next_change(date);
+
+                assert_eq!(
+                    next_change_1, next_change_2,
+                    "Next change differs at {date}: {next_change_1:?} != {next_change_2:?}"
+                );
             } else {
                 let ctx = Context::default().approx_bound_interval_size(MAX_INTERVAL_RANGE);
                 let oh_1 = oh_1.with_context(ctx.clone());
-                let oh_2 = oh_2.with_context(ctx.clone());
-                assert_eq!(oh_1.state(date), oh_2.state(date));
-                assert_eq!(oh_1.next_change(date), oh_2.next_change(date));
+                let oh_2 = oh_2.with_context(ctx);
+
+                // States should be equal
+                let state_1 = oh_1.state(date);
+                let state_2 = oh_2.state(date);
+
+                assert_eq!(
+                    state_1, state_2,
+                    "States differ at {date}: {state_1:?} != {state_2:?}"
+                );
+
+                // Next change should be equal
+                let next_change_1 = oh_1.next_change(date);
+                let next_change_2 = oh_2.next_change(date);
+
+                assert_eq!(
+                    next_change_1, next_change_2,
+                    "Next change differs at {date}: {next_change_1:?} != {next_change_2:?}"
+                );
             }
         }
     }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -72,34 +72,27 @@ impl Debug for Data {
 /// Run a fuzzing test and return `true` if the example should be kept in
 /// corpus.
 pub fn run_fuzz_oh(data: Data) -> bool {
-    eprintln!("[dbg] Input: {data:#?}");
-
     if data.oh.len() > MAX_OH_LENGTH {
-        eprintln!("[dbg] Skipping because of input size");
         return false;
     }
 
     let Some(date) = DateTime::from_timestamp(data.date_secs, 0) else {
-        eprintln!("[dbg] Skipping because of invalid input date");
         return false;
     };
 
     let date = date.naive_utc();
 
     if date.year() < 1900 || date.year() > 9999 {
-        eprintln!("[dbg] Skipping because of invalid date range");
         return false;
     }
 
     let Ok(oh_1) = OpeningHours::from_str(&data.oh) else {
-        eprintln!("[dbg] Skipping because of invalid input");
         return false;
     };
 
     match &data.operation {
         Operation::DoubleNormalize => {
             let normalized = oh_1.normalize();
-            eprintln!("[dbg] Normalized: {normalized:?}");
             assert_eq!(normalized, normalized.clone().normalize());
         }
         Operation::Compare(compare_with) => {
@@ -123,55 +116,21 @@ pub fn run_fuzz_oh(data: Data) -> bool {
                 }
             };
 
-            eprintln!("[dbg] Compare with {oh_2}");
-
             if let Some([lat, lon]) = data.coords_float() {
                 let ctx = Context::from_coords(Coordinates::new(lat, lon).unwrap())
                     .approx_bound_interval_size(MAX_INTERVAL_RANGE);
 
                 let date = ctx.locale.datetime(date);
                 let oh_1 = oh_1.with_context(ctx.clone());
-                let oh_2 = oh_2.with_context(ctx);
-
-                // States should be equal
-                let state_1 = oh_1.state(date);
-                let state_2 = oh_2.state(date);
-
-                assert_eq!(
-                    state_1, state_2,
-                    "States differ at {date}: {state_1:?} != {state_2:?}"
-                );
-
-                // Next change should be equal
-                let next_change_1 = oh_1.next_change(date);
-                let next_change_2 = oh_2.next_change(date);
-
-                assert_eq!(
-                    next_change_1, next_change_2,
-                    "Next change differs at {date}: {next_change_1:?} != {next_change_2:?}"
-                );
+                let oh_2 = oh_2.with_context(ctx.clone());
+                assert_eq!(oh_1.state(date), oh_2.state(date));
+                assert_eq!(oh_1.next_change(date), oh_2.next_change(date));
             } else {
                 let ctx = Context::default().approx_bound_interval_size(MAX_INTERVAL_RANGE);
                 let oh_1 = oh_1.with_context(ctx.clone());
-                let oh_2 = oh_2.with_context(ctx);
-
-                // States should be equal
-                let state_1 = oh_1.state(date);
-                let state_2 = oh_2.state(date);
-
-                assert_eq!(
-                    state_1, state_2,
-                    "States differ at {date}: {state_1:?} != {state_2:?}"
-                );
-
-                // Next change should be equal
-                let next_change_1 = oh_1.next_change(date);
-                let next_change_2 = oh_2.next_change(date);
-
-                assert_eq!(
-                    next_change_1, next_change_2,
-                    "Next change differs at {date}: {next_change_1:?} != {next_change_2:?}"
-                );
+                let oh_2 = oh_2.with_context(ctx.clone());
+                assert_eq!(oh_1.state(date), oh_2.state(date));
+                assert_eq!(oh_1.next_change(date), oh_2.next_change(date));
             }
         }
     }

--- a/opening-hours-py/Cargo.toml
+++ b/opening-hours-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-py"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -23,12 +23,12 @@ pyo3-stub-gen = "0.23"
 [dependencies.opening-hours-rs]
 package = "opening-hours"
 path = ".."
-version = "2.1.3"
+version = "2.1.4"
 features = ["log", "auto-country", "auto-timezone"]
 
 [dependencies.opening-hours-syntax]
 path = "../opening-hours-syntax"
-version = "2.1.3"
+version = "2.1.4"
 
 [dependencies.pyo3]
 version = "0.29"

--- a/opening-hours-py/src/lib.rs
+++ b/opening-hours-py/src/lib.rs
@@ -340,16 +340,20 @@ impl PyOpeningHours {
     /// | [weekday range][spec-weekday-range] with index in month | stop normalization (2)     | `Mo[2]`, `Mo[2] +1 days`     |
     /// | [weekday range][spec-weekday-range] with a holiday      | stop normalization (2)     | `easter`                     |
     /// | time that overlaps with next day                        | stop normalization (2)     | `22:00-06:00`, `22:00-28:00` |
-    /// | time with a solar event                                 | no time simplification (3) | `sunrise-18:00`              |
-    /// | time with an open end                                   | no time simplification (3) | `12:00-16:00+`               |
-    /// | time with repetition                                    | no time simplification (3) | `12:00-16:00/02:00`          |
+    /// | time ending at a solar event                            | stop normalization (2) (3) | `18:00-sunset`               |
+    /// | time starting at a solar event                          | no time simplification (4) | `sunrise-18:00`              |
+    /// | time with an open end                                   | no time simplification (4) | `12:00-16:00+`               |
+    /// | time with repetition                                    | no time simplification (4) | `12:00-16:00/02:00`          |
     ///
     /// Notes :
     ///
     /// 1. All the examples above contain a single rule, so they would be left
     ///    unchanged by the normalization.
     /// 2. This rule and any following rule won't be treated.
-    /// 3. This won't halt normalization but the algorithm won't try to merge this time
+    /// 3. There cannot be a guarantee that a variable time doesn't happen at the next
+    ///    day: you can always find a timezone or an extreme coordinate that doesn't
+    ///    fit.
+    /// 4. This won't halt normalization but the algorithm won't try to merge this time
     ///    range with others.
     ///
     /// If a feature is not implemented I may have considered it to be too niche for

--- a/opening-hours-syntax/Cargo.toml
+++ b/opening-hours-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opening-hours-syntax"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Rémi Dupré <remi@dupre.io>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/opening-hours-syntax/doc/normalize.md
+++ b/opening-hours-syntax/doc/normalize.md
@@ -37,16 +37,20 @@ normalized by current implementation:
 | [weekday range][spec-weekday-range] with index in month | stop normalization (2)     | `Mo[2]`, `Mo[2] +1 days`     |
 | [weekday range][spec-weekday-range] with a holiday      | stop normalization (2)     | `easter`                     |
 | time that overlaps with next day                        | stop normalization (2)     | `22:00-06:00`, `22:00-28:00` |
-| time with a solar event                                 | no time simplification (3) | `sunrise-18:00`              |
-| time with an open end                                   | no time simplification (3) | `12:00-16:00+`               |
-| time with repetition                                    | no time simplification (3) | `12:00-16:00/02:00`          |
+| time ending at a solar event                            | stop normalization (2) (3) | `18:00-sunset`               |
+| time starting at a solar event                          | no time simplification (4) | `sunrise-18:00`              |
+| time with an open end                                   | no time simplification (4) | `12:00-16:00+`               |
+| time with repetition                                    | no time simplification (4) | `12:00-16:00/02:00`          |
 
 Notes :
 
 1. All the examples above contain a single rule, so they would be left
    unchanged by the normalization.
 2. This rule and any following rule won't be treated.
-3. This won't halt normalization but the algorithm won't try to merge this time
+3. There cannot be a guarantee that a variable time doesn't happen at the next
+   day: you can always find a timezone or an extreme coordinate that doesn't
+   fit.
+4. This won't halt normalization but the algorithm won't try to merge this time
    range with others.
 
 If a feature is not implemented I may have considered it to be too niche for

--- a/opening-hours-syntax/src/normalize/canonical_time.rs
+++ b/opening-hours-syntax/src/normalize/canonical_time.rs
@@ -19,9 +19,8 @@ pub(crate) fn no_overlap_with_next_day(selector: &TimeSelector) -> bool {
             (Time::Fixed(start), Time::Fixed(end)) => {
                 start < end && end <= ExtendedTime::MIDNIGHT_24
             }
-            (Time::Fixed(start), Time::Variable(_)) => start == ExtendedTime::MIDNIGHT_00,
             (Time::Variable(_), Time::Fixed(end)) => end == ExtendedTime::MIDNIGHT_24,
-            (Time::Variable(start), Time::Variable(end)) => start.is_before(&end),
+            _ => false,
         })
 }
 

--- a/opening-hours-syntax/src/tests/normalize.rs
+++ b/opening-hours-syntax/src/tests/normalize.rs
@@ -27,9 +27,6 @@ use crate::rules::OpeningHoursExpression;
 #[case("Sep23:30-04:20", "Sep 23:30-04:20")]
 #[case("Sa;Su;2490-2490/8", "2490; 1900-2489,2491-9999 Sa-Su")]
 #[case("Mo 10:00-21:00; Tu,We,Th,Fr,Sa,Su 10:00-21:00", "10:00-21:00")]
-#[case("dusk-dawn+;Mo", "dusk-dawn+; Mo")] // dusk-dawn is wrapping, not normalized
-#[case("dusk-dusk;Mo", "dusk-dusk; Mo")] // dusk-dusk is wrapping too
-#[case("dawn-dusk+;Mo", "Mo; Tu-Su dawn-dusk+")] // dawn-dusk is not wrapping
 #[case("Jun; 02:00-02:00", "Jun; 02:00-02:00")]
 #[case(
     "week2Mo;Jun;Fr",
@@ -79,17 +76,10 @@ use crate::rules::OpeningHoursExpression;
     r#"Mo-Su 08:00-14:00 open, Mo-Su 10:00-18:00 unknown; Mo-Su 18:00-20:00 closed "may vary""#,
     r#"08:00-10:00, Mo-Su 10:00-18:00 unknown, Mo-Su 18:00-20:00 closed "may vary""#
 )]
+#[case::time_selector("10:00-16:00; Mo sunset-24:00", "Mo sunset-24:00; Tu-Su 10:00-16:00")]
 #[case::time_selector(
-    "10:00-16:00; Mo sunrise-sunset",
-    "Mo sunrise-sunset; Tu-Su 10:00-16:00"
-)]
-#[case::time_selector( // variable time should be sorted
-    "(sunrise-00:30)-sunset,(sunrise-01:00)-sunset,sunrise-sunset,sunrise-(sunset+00:30)",
-    "(sunrise-01:00)-sunset,(sunrise-00:30)-sunset,sunrise-sunset,sunrise-(sunset+00:30)"
-)]
-#[case::time_selector(
-    "sunrise-sunset; Th 10:00-14:00",
-    "Mo-We,Fr-Su sunrise-sunset; Th 10:00-14:00"
+    "sunrise-24:00; Th 10:00-14:00",
+    "Mo-We,Fr-Su sunrise-24:00; Th 10:00-14:00"
 )]
 fn normalize(#[case] example: OpeningHoursExpression, #[case] normalized_expected: &str) {
     let normalized = example.normalize();
@@ -110,6 +100,10 @@ fn normalize(#[case] example: OpeningHoursExpression, #[case] normalized_expecte
 #[rstest]
 // There was an issue with 53 being the last possible value
 #[case("6246 week06; 4497 We; 6246 week07-53 We")]
+// Time ranges ending in events cannot be normalized
+#[case("dusk-dawn+; Mo")]
+#[case("dusk-dusk; Mo")]
+#[case("dawn-dusk+; Mo")]
 fn stays_normalized(#[case] example: &str) {
     let oh: OpeningHoursExpression = example.parse().expect("could not part input expression");
     let normalized = oh.normalize();

--- a/opening-hours/src/filter/time_filter.rs
+++ b/opening-hours/src/filter/time_filter.rs
@@ -140,7 +140,7 @@ impl TimeFilter for ts::TimeSpan {
             }
         };
 
-        assert!(start <= end);
+        debug_assert!(start <= end);
         Some(start..end)
     }
 }

--- a/opening_hours.pyi
+++ b/opening_hours.pyi
@@ -119,16 +119,20 @@ class OpeningHours:
         | [weekday range][spec-weekday-range] with index in month | stop normalization (2)     | `Mo[2]`, `Mo[2] +1 days`     |
         | [weekday range][spec-weekday-range] with a holiday      | stop normalization (2)     | `easter`                     |
         | time that overlaps with next day                        | stop normalization (2)     | `22:00-06:00`, `22:00-28:00` |
-        | time with a solar event                                 | no time simplification (3) | `sunrise-18:00`              |
-        | time with an open end                                   | no time simplification (3) | `12:00-16:00+`               |
-        | time with repetition                                    | no time simplification (3) | `12:00-16:00/02:00`          |
+        | time ending at a solar event                            | stop normalization (2) (3) | `18:00-sunset`               |
+        | time starting at a solar event                          | no time simplification (4) | `sunrise-18:00`              |
+        | time with an open end                                   | no time simplification (4) | `12:00-16:00+`               |
+        | time with repetition                                    | no time simplification (4) | `12:00-16:00/02:00`          |
 
         Notes :
 
         1. All the examples above contain a single rule, so they would be left
            unchanged by the normalization.
         2. This rule and any following rule won't be treated.
-        3. This won't halt normalization but the algorithm won't try to merge this time
+        3. There cannot be a guarantee that a variable time doesn't happen at the next
+           day: you can always find a timezone or an extreme coordinate that doesn't
+           fit.
+        4. This won't halt normalization but the algorithm won't try to merge this time
            range with others.
 
         If a feature is not implemented I may have considered it to be too niche for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ changelog = "https://github.com/remi-dupre/opening-hours-rs/blob/master/CHANGELO
 readme = "opening-hours-py/README.md"
 authors = [{name = "Rémi Dupré", email = "remi+openinghours@dupre.io"}]
 requires-python = "~=3.10"
-version = "2.1.3"
+version = "2.1.4"
 dynamic = ["license", "license-files"]
 
 [dependency-groups]


### PR DESCRIPTION

## 📋 Before Merge Checklist

1. [x] I have chosen a new version number with respect to [semver](https://semver.org/)
2. [X] I have updated the version in these files consistently: *Cargo.toml*, *compact-calendar/Cargo.toml*, *opening-hours-syntax/Cargo.toml*, *python/Cargo.toml* and *pyproject.toml*
3. [x] I have updated *CHANGELOG.md*
